### PR TITLE
Emit absolute URLs instead of relative when rendering links and images

### DIFF
--- a/src/org/intellij/markdown/flavours/MarkdownFlavourDescriptor.kt
+++ b/src/org/intellij/markdown/flavours/MarkdownFlavourDescriptor.kt
@@ -6,6 +6,7 @@ import org.intellij.markdown.lexer.MarkdownLexer
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkerProcessorFactory
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
+import java.net.URI
 
 public interface MarkdownFlavourDescriptor {
     val markerProcessorFactory: MarkerProcessorFactory
@@ -14,5 +15,5 @@ public interface MarkdownFlavourDescriptor {
 
     fun createInlinesLexer(): MarkdownLexer
 
-    fun createHtmlGeneratingProviders(linkMap: LinkMap): Map<IElementType, GeneratingProvider>
+    fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider>
 }

--- a/src/org/intellij/markdown/flavours/commonmark/CommonMarkFlavourDescriptor.kt
+++ b/src/org/intellij/markdown/flavours/commonmark/CommonMarkFlavourDescriptor.kt
@@ -17,6 +17,7 @@ import org.intellij.markdown.parser.sequentialparsers.SequentialParser
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
 import org.intellij.markdown.parser.sequentialparsers.impl.*
 import java.io.Reader
+import java.net.URI
 
 public open class CommonMarkFlavourDescriptor : MarkdownFlavourDescriptor {
     override val markerProcessorFactory: MarkerProcessorFactory = CommonMarkMarkerProcessor.Factory
@@ -36,7 +37,7 @@ public open class CommonMarkFlavourDescriptor : MarkdownFlavourDescriptor {
         }
     }
 
-    override fun createHtmlGeneratingProviders(linkMap: LinkMap): Map<IElementType, GeneratingProvider> = hashMapOf(
+    override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider> = hashMapOf(
 
             MarkdownElementTypes.MARKDOWN_FILE to SimpleTagProvider("body"),
             MarkdownElementTypes.HTML_BLOCK to HtmlBlockGeneratingProvider(),
@@ -93,12 +94,12 @@ public open class CommonMarkFlavourDescriptor : MarkdownFlavourDescriptor {
             MarkdownElementTypes.LINK_TEXT to TransparentInlineHolderProvider(),
             MarkdownElementTypes.LINK_TITLE to TransparentInlineHolderProvider(),
 
-            MarkdownElementTypes.INLINE_LINK to InlineLinkGeneratingProvider(),
+            MarkdownElementTypes.INLINE_LINK to InlineLinkGeneratingProvider(baseURI),
 
-            MarkdownElementTypes.FULL_REFERENCE_LINK to ReferenceLinksGeneratingProvider(linkMap),
-            MarkdownElementTypes.SHORT_REFERENCE_LINK to ReferenceLinksGeneratingProvider(linkMap),
+            MarkdownElementTypes.FULL_REFERENCE_LINK to ReferenceLinksGeneratingProvider(linkMap, baseURI),
+            MarkdownElementTypes.SHORT_REFERENCE_LINK to ReferenceLinksGeneratingProvider(linkMap, baseURI),
 
-            MarkdownElementTypes.IMAGE to ImageGeneratingProvider(linkMap),
+            MarkdownElementTypes.IMAGE to ImageGeneratingProvider(linkMap, baseURI),
 
             MarkdownElementTypes.LINK_DEFINITION to object : GeneratingProvider {
                 override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {

--- a/src/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
+++ b/src/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
@@ -17,6 +17,7 @@ import org.intellij.markdown.parser.sequentialparsers.SequentialParser
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
 import org.intellij.markdown.parser.sequentialparsers.impl.*
 import java.io.Reader
+import java.net.URI
 
 public class GFMFlavourDescriptor : CommonMarkFlavourDescriptor() {
     override val markerProcessorFactory = GFMMarkerProcessor.Factory
@@ -37,8 +38,8 @@ public class GFMFlavourDescriptor : CommonMarkFlavourDescriptor() {
         }
     }
 
-    override fun createHtmlGeneratingProviders(linkMap: LinkMap): Map<IElementType, GeneratingProvider> {
-        return super.createHtmlGeneratingProviders(linkMap) + hashMapOf(
+    override fun createHtmlGeneratingProviders(linkMap: LinkMap, baseURI: URI?): Map<IElementType, GeneratingProvider> {
+        return super.createHtmlGeneratingProviders(linkMap, baseURI) + hashMapOf(
                 GFMElementTypes.STRIKETHROUGH to object: SimpleInlineTagProvider("span", 2, -2) {
                     override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
                         visitor.consumeTagOpen(node, tagName, "class=\"user-del\"")

--- a/src/org/intellij/markdown/html/GeneratingProviders.kt
+++ b/src/org/intellij/markdown/html/GeneratingProviders.kt
@@ -187,9 +187,17 @@ internal abstract class LinkGeneratingProvider(protected val baseURI: URI?) : Ge
         renderLink(visitor, text, node, info)
     }
 
+    protected fun makeAbsoluteUrl(destination : CharSequence) : CharSequence {
+        try {
+            return baseURI?.resolve(destination.toString())?.toString() ?: destination
+        }
+        catch (e : IllegalArgumentException) {
+            return destination
+        }
+    }
+
     open fun renderLink(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode, info: RenderInfo) {
-        val target : CharSequence = baseURI?.resolve(info.destination.toString())?.toString() ?: info.destination
-        visitor.consumeTagOpen(node, "a", "href=\"${target}\"", info.title?.let { "title=\"$it\"" })
+        visitor.consumeTagOpen(node, "a", "href=\"${makeAbsoluteUrl(info.destination)}\"", info.title?.let { "title=\"$it\"" })
         labelProvider.processNode(visitor, text, info.label)
         visitor.consumeTagClose("a")
     }
@@ -255,9 +263,8 @@ internal class ImageGeneratingProvider(linkMap: LinkMap, baseURI: URI?) : LinkGe
     }
 
     override fun renderLink(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode, info: LinkGeneratingProvider.RenderInfo) {
-        val target : CharSequence = baseURI?.resolve(info.destination.toString())?.toString() ?: info.destination
         visitor.consumeTagOpen(node, "img",
-                "src=\"${target}\"",
+                "src=\"${makeAbsoluteUrl(info.destination)}\"",
                 "alt=\"${getPlainTextFrom(info.label, text)}\"",
                 info.title?.let { "title=\"$it\"" },
                 autoClose = true)

--- a/src/org/intellij/markdown/html/HtmlGenerator.kt
+++ b/src/org/intellij/markdown/html/HtmlGenerator.kt
@@ -9,14 +9,16 @@ import org.intellij.markdown.ast.visitors.RecursiveVisitor
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.html.entities.EntityConverter
 import org.intellij.markdown.parser.LinkMap
+import java.net.URI
 
 
 public class HtmlGenerator(private val markdownText: String,
                            private val root: ASTNode,
                            flavour: MarkdownFlavourDescriptor,
                            linkMap: LinkMap = LinkMap.buildLinkMap(root, markdownText),
-                           private val includeSrcPositions: Boolean = false) {
-    private val providers: Map<IElementType, GeneratingProvider> = flavour.createHtmlGeneratingProviders(linkMap)
+                           private val includeSrcPositions: Boolean = false,
+                           baseURI: URI? = null) {
+    private val providers: Map<IElementType, GeneratingProvider> = flavour.createHtmlGeneratingProviders(linkMap, baseURI)
     private val htmlString: StringBuilder = StringBuilder()
 
     public fun generateHtml(): String {

--- a/test/data/html/baseUriFile.md
+++ b/test/data/html/baseUriFile.md
@@ -1,0 +1,8 @@
+* [implicit current directory relative inline link](baz.html)
+* [explicit current directory relative inline link](./baz.html)
+* [parent directory relative inline link](../quux.html)
+* [absolute inline link](https://google.com/)
+* ![implicit current directory relative inline image](baz-image.png)
+* ![explicit current directory relative inline image](./baz-image.png)
+* ![parent directory relative inline image](../quux-image.png)
+* ![absolute inline image](http://example.com/not-real.png)

--- a/test/data/html/baseUriFile.txt
+++ b/test/data/html/baseUriFile.txt
@@ -1,0 +1,24 @@
+<body>
+<ul>
+<li>
+<a href="file:/c:/foo/baz.html">implicit current directory relative inline link</a>
+</li>
+<li>
+<a href="file:/c:/foo/baz.html">explicit current directory relative inline link</a>
+</li>
+<li>
+<a href="file:/c:/quux.html">parent directory relative inline link</a>
+</li>
+<li>
+<a href="https://google.com/">absolute inline link</a>
+</li>
+<li>
+<img src="file:/c:/foo/baz-image.png" alt="implicit current directory relative inline image" /></li>
+<li>
+<img src="file:/c:/foo/baz-image.png" alt="explicit current directory relative inline image" /></li>
+<li>
+<img src="file:/c:/quux-image.png" alt="parent directory relative inline image" /></li>
+<li>
+<img src="http://example.com/not-real.png" alt="absolute inline image" /></li>
+</ul>
+</body>

--- a/test/data/html/baseUriHttp.md
+++ b/test/data/html/baseUriHttp.md
@@ -1,0 +1,8 @@
+* [implicit current directory relative inline link](baz.html)
+* [explicit current directory relative inline link](./baz.html)
+* [parent directory relative inline link](../quux.html)
+* [absolute inline link](https://google.com/)
+* ![implicit current directory relative inline image](baz-image.png)
+* ![explicit current directory relative inline image](./baz-image.png)
+* ![parent directory relative inline image](../quux-image.png)
+* ![absolute inline image](http://example.com/not-real.png)

--- a/test/data/html/baseUriHttp.txt
+++ b/test/data/html/baseUriHttp.txt
@@ -1,0 +1,24 @@
+<body>
+<ul>
+<li>
+<a href="http://example.com/foo/baz.html">implicit current directory relative inline link</a>
+</li>
+<li>
+<a href="http://example.com/foo/baz.html">explicit current directory relative inline link</a>
+</li>
+<li>
+<a href="http://example.com/quux.html">parent directory relative inline link</a>
+</li>
+<li>
+<a href="https://google.com/">absolute inline link</a>
+</li>
+<li>
+<img src="http://example.com/foo/baz-image.png" alt="implicit current directory relative inline image" /></li>
+<li>
+<img src="http://example.com/foo/baz-image.png" alt="explicit current directory relative inline image" /></li>
+<li>
+<img src="http://example.com/quux-image.png" alt="parent directory relative inline image" /></li>
+<li>
+<img src="http://example.com/not-real.png" alt="absolute inline image" /></li>
+</ul>
+</body>

--- a/test/org/intellij/markdown/HtmlGeneratorTest.kt
+++ b/test/org/intellij/markdown/HtmlGeneratorTest.kt
@@ -7,13 +7,14 @@ import org.intellij.markdown.flavours.gfm.GFMFlavourDescriptor
 import org.intellij.markdown.html.HtmlGenerator
 import org.intellij.markdown.parser.MarkdownParser
 import java.io.File
+import java.net.URI
 import kotlin.text.Regex
 
 public class HtmlGeneratorTest : TestCase() {
-    private fun defaultTest(flavour: MarkdownFlavourDescriptor = CommonMarkFlavourDescriptor()) {
+    private fun defaultTest(flavour: MarkdownFlavourDescriptor = CommonMarkFlavourDescriptor(), baseURI: URI? = null) {
         val src = File(getTestDataPath() + "/" + testName + ".md").readText();
         val tree = MarkdownParser(flavour).buildMarkdownTreeFromString(src);
-        val html = HtmlGenerator(src, tree, flavour).generateHtml()
+        val html = HtmlGenerator(src, tree, flavour, includeSrcPositions = false, baseURI = baseURI).generateHtml()
 
         val result = formatHtmlForTests(html)
 
@@ -110,6 +111,14 @@ public class HtmlGeneratorTest : TestCase() {
 
     public fun testGitBook() {
         defaultTest()
+    }
+
+    public fun testBaseUriHttp() {
+        defaultTest(baseURI = URI("http://example.com/foo/bar.html"))
+    }
+
+    public fun testBaseUriFile() {
+        defaultTest(baseURI = URI("file:///c:/foo/bar.html"))
     }
 
     companion object {

--- a/test/org/intellij/markdown/SpecRunner.java
+++ b/test/org/intellij/markdown/SpecRunner.java
@@ -17,7 +17,7 @@ public class SpecRunner {
         final MarkdownFlavourDescriptor flavour = new CommonMarkFlavourDescriptor();
         final ASTNode tree = new MarkdownParser(flavour)
                 .buildMarkdownTreeFromString(content);
-        final String html = new HtmlGenerator(content, tree, flavour, LinkMap.Builder.buildLinkMap(tree, content), false)
+        final String html = new HtmlGenerator(content, tree, flavour, LinkMap.Builder.buildLinkMap(tree, content), false, null)
                 .generateHtml();
         final String htmlWithoutBody = html.substring("<body>".length(), html.length() - "</body>".length());
 


### PR DESCRIPTION
Produce absolute paths to relative URIs while rendering links and images.

I'm not 100% happy with this, it feels like I had to add the base URI in too many places, but here we are.