### PR TITLE
Normalization for local image urls.

### DIFF
--- a/src/org/intellij/markdown/flavours/MarkdownFlavourDescriptor.kt
+++ b/src/org/intellij/markdown/flavours/MarkdownFlavourDescriptor.kt
@@ -6,6 +6,7 @@ import org.intellij.markdown.lexer.MarkdownLexer
 import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.MarkerProcessorFactory
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
+import java.io.File
 
 public interface MarkdownFlavourDescriptor {
     val markerProcessorFactory: MarkerProcessorFactory
@@ -14,5 +15,5 @@ public interface MarkdownFlavourDescriptor {
 
     fun createInlinesLexer(): MarkdownLexer
 
-    fun createHtmlGeneratingProviders(linkMap: LinkMap): Map<IElementType, GeneratingProvider>
+    fun createHtmlGeneratingProviders(linkMap: LinkMap, documentBase: File?): Map<IElementType, GeneratingProvider>
 }

--- a/src/org/intellij/markdown/flavours/commonmark/CommonMarkFlavourDescriptor.kt
+++ b/src/org/intellij/markdown/flavours/commonmark/CommonMarkFlavourDescriptor.kt
@@ -16,6 +16,7 @@ import org.intellij.markdown.parser.MarkerProcessorFactory
 import org.intellij.markdown.parser.sequentialparsers.SequentialParser
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
 import org.intellij.markdown.parser.sequentialparsers.impl.*
+import java.io.File
 import java.io.Reader
 
 public open class CommonMarkFlavourDescriptor : MarkdownFlavourDescriptor {
@@ -36,7 +37,7 @@ public open class CommonMarkFlavourDescriptor : MarkdownFlavourDescriptor {
         }
     }
 
-    override fun createHtmlGeneratingProviders(linkMap: LinkMap): Map<IElementType, GeneratingProvider> = hashMapOf(
+    override fun createHtmlGeneratingProviders(linkMap: LinkMap, documentBase: File?): Map<IElementType, GeneratingProvider> = hashMapOf(
 
             MarkdownElementTypes.MARKDOWN_FILE to SimpleTagProvider("body"),
             MarkdownElementTypes.HTML_BLOCK to HtmlBlockGeneratingProvider(),
@@ -98,7 +99,7 @@ public open class CommonMarkFlavourDescriptor : MarkdownFlavourDescriptor {
             MarkdownElementTypes.FULL_REFERENCE_LINK to ReferenceLinksGeneratingProvider(linkMap),
             MarkdownElementTypes.SHORT_REFERENCE_LINK to ReferenceLinksGeneratingProvider(linkMap),
 
-            MarkdownElementTypes.IMAGE to ImageGeneratingProvider(linkMap),
+            MarkdownElementTypes.IMAGE to ImageGeneratingProvider(linkMap, documentBase),
 
             MarkdownElementTypes.LINK_DEFINITION to object : GeneratingProvider {
                 override fun processNode(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {

--- a/src/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
+++ b/src/org/intellij/markdown/flavours/gfm/GFMFlavourDescriptor.kt
@@ -16,6 +16,7 @@ import org.intellij.markdown.parser.LinkMap
 import org.intellij.markdown.parser.sequentialparsers.SequentialParser
 import org.intellij.markdown.parser.sequentialparsers.SequentialParserManager
 import org.intellij.markdown.parser.sequentialparsers.impl.*
+import java.io.File
 import java.io.Reader
 
 public class GFMFlavourDescriptor : CommonMarkFlavourDescriptor() {
@@ -37,8 +38,8 @@ public class GFMFlavourDescriptor : CommonMarkFlavourDescriptor() {
         }
     }
 
-    override fun createHtmlGeneratingProviders(linkMap: LinkMap): Map<IElementType, GeneratingProvider> {
-        return super.createHtmlGeneratingProviders(linkMap) + hashMapOf(
+    override fun createHtmlGeneratingProviders(linkMap: LinkMap, documentBase: File?): Map<IElementType, GeneratingProvider> {
+        return super.createHtmlGeneratingProviders(linkMap, documentBase) + hashMapOf(
                 GFMElementTypes.STRIKETHROUGH to object: SimpleInlineTagProvider("span", 2, -2) {
                     override fun openTag(visitor: HtmlGenerator.HtmlGeneratingVisitor, text: String, node: ASTNode) {
                         visitor.consumeTagOpen(node, tagName, "class=\"user-del\"")

--- a/src/org/intellij/markdown/html/HtmlGenerator.kt
+++ b/src/org/intellij/markdown/html/HtmlGenerator.kt
@@ -9,14 +9,16 @@ import org.intellij.markdown.ast.visitors.RecursiveVisitor
 import org.intellij.markdown.flavours.MarkdownFlavourDescriptor
 import org.intellij.markdown.html.entities.EntityConverter
 import org.intellij.markdown.parser.LinkMap
+import java.io.File
 
 
 public class HtmlGenerator(private val markdownText: String,
                            private val root: ASTNode,
                            flavour: MarkdownFlavourDescriptor,
                            linkMap: LinkMap = LinkMap.buildLinkMap(root, markdownText),
-                           private val includeSrcPositions: Boolean = false) {
-    private val providers: Map<IElementType, GeneratingProvider> = flavour.createHtmlGeneratingProviders(linkMap)
+                           private val includeSrcPositions: Boolean = false,
+                           private val documentBase: File? = null) {
+    private val providers: Map<IElementType, GeneratingProvider> = flavour.createHtmlGeneratingProviders(linkMap, documentBase)
     private val htmlString: StringBuilder = StringBuilder()
 
     public fun generateHtml(): String {

--- a/test/org/intellij/markdown/SpecRunner.java
+++ b/test/org/intellij/markdown/SpecRunner.java
@@ -17,7 +17,7 @@ public class SpecRunner {
         final MarkdownFlavourDescriptor flavour = new CommonMarkFlavourDescriptor();
         final ASTNode tree = new MarkdownParser(flavour)
                 .buildMarkdownTreeFromString(content);
-        final String html = new HtmlGenerator(content, tree, flavour, LinkMap.Builder.buildLinkMap(tree, content), false)
+        final String html = new HtmlGenerator(content, tree, flavour, LinkMap.Builder.buildLinkMap(tree, content), false, null)
                 .generateHtml();
         final String htmlWithoutBody = html.substring("<body>".length(), html.length() - "</body>".length());
 


### PR DESCRIPTION
I'd love the Jetbrains Markdown plugin to support local images in the preview. Since WebView in JavaFX does not support those yet (see [here](http://stackoverflow.com/questions/26447451/javafx-in-webview-img-tag-is-not-loading-local-images) or [here](http://stackoverflow.com/questions/12288697/can-not-display-local-image-file-as-webengine-image-src-attribute)), I've added a simple url-normalization scheme to your library to normalize relative image urls when rendering html from md.

To use this modification in the JB plugin, i all that's necessary is to change in instantiation fo the `HtmlGenerator` in `org.intellij.plugins.markdown.ui.preview.MarkdownPreviewFileEditor`. Here's the patch file:
[relative_image_in_md_preview.patch.txt](https://github.com/valich/intellij-markdown/files/200802/relative_image_in_md_preview.patch.txt)


The patch is well tested with the JavaFx Preview Mode in the Markdown plugin, but should also work with LoboHtmlPanel.


Attached is also a patched build of the JB Markdown plugin including the changes so that you could test it easily:
[markdown-plugin.zip](https://github.com/valich/intellij-markdown/files/200798/markdown-plugin.zip)

Here's a screenshot of a relative image example
<img width="927" alt="rel_images_in_md_preview" src="https://cloud.githubusercontent.com/assets/200952/14226056/86cdd9f6-f8d7-11e5-8594-bbee80a29a4e.png">

Feel welcome if you think that my PR still needs refinements.
