### PR TITLE
Set compatibility to 1.6 so one can use it on android

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -88,3 +88,6 @@ jar {
 if (hasProperty("bintrayUser")) {
     apply from: "deploy.gradle"
 }
+
+sourceCompatibility=1.6
+targetCompatibility=1.6


### PR DESCRIPTION
I want to use this library on android - Kotlin compiles to 1.6 by default - but there is some java code included so we have to set this to be compatible