### PR TITLE
Don't resolve bookmark links of type `#link` to absolute URL

### DIFF
--- a/src/org/intellij/markdown/html/GeneratingProviders.kt
+++ b/src/org/intellij/markdown/html/GeneratingProviders.kt
@@ -189,6 +189,9 @@ internal abstract class LinkGeneratingProvider(protected val baseURI: URI?) : Ge
 
     protected fun makeAbsoluteUrl(destination : CharSequence) : CharSequence {
         try {
+            if (destination.startsWith('#')) {
+                return destination
+            }
             return baseURI?.resolve(destination.toString())?.toString() ?: destination
         }
         catch (e : IllegalArgumentException) {


### PR DESCRIPTION
When generating HTML for a local .md file providing it's path as base URL bookmark links of type `#link` are prepended with base URL like - `/Users/.../baseDir/#link` and that's incorrect.

Let's leave bookmark links related and not absolute - just `#link`.